### PR TITLE
Creating Tabular Navigation in App

### DIFF
--- a/HelloARWorld.xcodeproj/project.pbxproj
+++ b/HelloARWorld.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		358DD35C2BF8839100D78478 /* HelloARWorldUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358DD35B2BF8839100D78478 /* HelloARWorldUITestsLaunchTests.swift */; };
 		358DD3692BF8881600D78478 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358DD3682BF8881600D78478 /* ViewController.swift */; };
 		358DD36B2BF8888200D78478 /* ARViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358DD36A2BF8888200D78478 /* ARViewContainer.swift */; };
+		3597C7B32C16167600B7DB46 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3597C7B22C16167600B7DB46 /* MainView.swift */; };
+		3597C7B52C1616B100B7DB46 /* SocialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3597C7B42C1616B100B7DB46 /* SocialView.swift */; };
+		3597C7B72C1616C000B7DB46 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3597C7B62C1616C000B7DB46 /* ProfileView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +55,9 @@
 		358DD35B2BF8839100D78478 /* HelloARWorldUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelloARWorldUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		358DD3682BF8881600D78478 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		358DD36A2BF8888200D78478 /* ARViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARViewContainer.swift; sourceTree = "<group>"; };
+		3597C7B22C16167600B7DB46 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		3597C7B42C1616B100B7DB46 /* SocialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialView.swift; sourceTree = "<group>"; };
+		3597C7B62C1616C000B7DB46 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +116,9 @@
 				358DD36A2BF8888200D78478 /* ARViewContainer.swift */,
 				35805FC32C0782D2001B3C92 /* OptionsViewController.swift */,
 				35805FC52C078307001B3C92 /* OptionsViewControllerWrapper.swift */,
+				3597C7B22C16167600B7DB46 /* MainView.swift */,
+				3597C7B42C1616B100B7DB46 /* SocialView.swift */,
+				3597C7B62C1616C000B7DB46 /* ProfileView.swift */,
 			);
 			path = HelloARWorld;
 			sourceTree = "<group>";
@@ -275,6 +284,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				358DD3692BF8881600D78478 /* ViewController.swift in Sources */,
+				3597C7B72C1616C000B7DB46 /* ProfileView.swift in Sources */,
+				3597C7B52C1616B100B7DB46 /* SocialView.swift in Sources */,
+				3597C7B32C16167600B7DB46 /* MainView.swift in Sources */,
 				358DD36B2BF8888200D78478 /* ARViewContainer.swift in Sources */,
 				358DD3412BF8839000D78478 /* ContentView.swift in Sources */,
 				35805FC62C078307001B3C92 /* OptionsViewControllerWrapper.swift in Sources */,

--- a/HelloARWorld/ContentView.swift
+++ b/HelloARWorld/ContentView.swift
@@ -48,3 +48,9 @@ struct ContentView: View {
         }
     }
 }
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/HelloARWorld/HelloARWorldApp.swift
+++ b/HelloARWorld/HelloARWorldApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct HelloARWorldApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainView()
         }
     }
 }

--- a/HelloARWorld/MainView.swift
+++ b/HelloARWorld/MainView.swift
@@ -25,13 +25,35 @@ struct MainView: View {
         }
     }
     
-    // Function to ensure the tab bar remains visible
+    // Function to ensure the tab bar remains visible and styled
     func setupTabBarAppearance() {
-        let appearance = UITabBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor.systemBackground
-        UITabBar.appearance().scrollEdgeAppearance = appearance
-        UITabBar.appearance().standardAppearance = appearance
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithOpaqueBackground()
+        
+        // Customize background color
+        tabBarAppearance.backgroundColor = UIColor.systemBackground
+        
+        // Customize selected item appearance
+        let selectedAppearance = UITabBarItemAppearance()
+        selectedAppearance.selected.iconColor = UIColor.systemBlue
+        selectedAppearance.selected.titleTextAttributes = [.foregroundColor: UIColor.systemBlue]
+        
+        // Customize normal item appearance
+        let normalAppearance = UITabBarItemAppearance()
+        normalAppearance.normal.iconColor = UIColor.gray
+        normalAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.gray]
+        
+        // Apply the custom appearances to the tab bar
+        tabBarAppearance.stackedLayoutAppearance = normalAppearance
+        tabBarAppearance.stackedLayoutAppearance = selectedAppearance
+
+        // Apply the appearance to the tab bar
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        
+        // Optional: Customize shadow
+        tabBarAppearance.shadowColor = UIColor.lightGray
+        tabBarAppearance.shadowImage = UIImage()
     }
 }
 

--- a/HelloARWorld/MainView.swift
+++ b/HelloARWorld/MainView.swift
@@ -19,6 +19,19 @@ struct MainView: View {
                     Text("Profile")
                 }
         }
+        .onAppear {
+            // Configure tab bar appearance to ensure it is always visible
+            setupTabBarAppearance()
+        }
+    }
+    
+    // Function to ensure the tab bar remains visible
+    func setupTabBarAppearance() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor.systemBackground
+        UITabBar.appearance().scrollEdgeAppearance = appearance
+        UITabBar.appearance().standardAppearance = appearance
     }
 }
 

--- a/HelloARWorld/MainView.swift
+++ b/HelloARWorld/MainView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct MainView: View {
+    var body: some View {
+        TabView {
+            SocialView()
+                .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("Home")
+                }
+            ContentView()
+                .tabItem {
+                    Image(systemName: "camera.viewfinder")
+                    Text("Scan")
+                }
+            ProfileView()
+                .tabItem {
+                    Image(systemName: "person.crop.circle")
+                    Text("Profile")
+                }
+        }
+    }
+}
+
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView()
+    }
+}

--- a/HelloARWorld/ProfileView.swift
+++ b/HelloARWorld/ProfileView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        Text("Profile View")
+            .font(.largeTitle)
+            .padding()
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView()
+    }
+}

--- a/HelloARWorld/SocialView.swift
+++ b/HelloARWorld/SocialView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct SocialView: View {
+    var body: some View {
+        Text("Social View")
+            .font(.largeTitle)
+            .padding()
+    }
+}
+
+struct SocialView_Previews: PreviewProvider {
+    static var previews: some View {
+        SocialView()
+    }
+}


### PR DESCRIPTION
With the merge of this branch, the user will now have access to tabular navigation within the app. There is a **home**, **scan**, and **profile** tab. 

**Home Tab:**
This is where all the social content of the app will go. The user will be able to share routes, like, comment, and share other users routes, and engage within the community. There will also be an option to use the route as a template for the user to edit for their home gym. 

**Scan Tab:**
This is where the user can create and edit routes. They'll be able to place holds, edit existing routes, etc.

**Profile Tab:**
This is where the user can see and manage account information such as posts, account credentials, etc.
